### PR TITLE
Atualização da Imagem hello-app para novo SHA

### DIFF
--- a/hello-app/deployment.yaml
+++ b/hello-app/deployment.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: hello-app
-        image: fassir/hello-app:latest 
+        image: fassir/hello-app:f7cd0995042e4d549e694cbb39c3f6138d02da96
         ports:
         - containerPort: 8000


### PR DESCRIPTION
Este Pull Request atualiza a tag da imagem `hello-app` para o novo SHA: `f7cd0995042e4d549e694cbb39c3f6138d02da96` no `deployment.yaml`.
Disparado por push no repositório da aplicação.